### PR TITLE
Fix optional return of `Geometry.centroid`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem install cocoapods -v '1.2.1'
   - pod repo update
 
-osx_image: xcode8.3
+osx_image: xcode9
 
 cache: cocoapods
 
@@ -13,10 +13,10 @@ env:
   global:
     - WORKSPACE=GEOSwiftMapboxGL.xcworkspace
     - SCHEME=GEOSwiftMapboxGL
-    - SDK=iphonesimulator10.3
+    - SDK=iphonesimulator11.0
   matrix:
     # - DESTINATION="OS=10.3,name=iPhone 6"
-    - DESTINATION="OS=9.3,name=iPhone 6"
+    - DESTINATION="OS=11.0,name=iPhone 6"
     # - DESTINATION="OS=8.3,name=iPhone 6"
 
 script:

--- a/GEOSwiftMapboxGL.podspec
+++ b/GEOSwiftMapboxGL.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, "8.0"
 
-  s.dependency "GEOSwift"
+  s.dependency "GEOSwift", '~> 2.2'
   s.dependency "Mapbox-iOS-SDK"
 
 end

--- a/GEOSwiftMapboxGL/MapboxGLAnnotations.swift
+++ b/GEOSwiftMapboxGL/MapboxGLAnnotations.swift
@@ -85,7 +85,13 @@ public class MGLShapesCollection : MGLShape, MGLOverlay {
             MGLShape in
             return geometry.mapboxShape()
         })
-        self.centroid = CLLocationCoordinate2DFromCoordinate(geometryCollection.centroid().coordinate)
+
+        if let coordinate = geometryCollection.centroid()?.coordinate {
+            self.centroid = CLLocationCoordinate2DFromCoordinate(coordinate)
+        } else {
+            self.centroid = CLLocationCoordinate2DFromCoordinate(CoordinateFromCLLocationCoordinate2D(CLLocationCoordinate2DMake(0, 0)))
+        }
+
         self.shapes = shapes
         
         if let envelope = geometryCollection.envelope() as? Polygon {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,20 +1,24 @@
 PODS:
   - geos (3.5.0)
-  - GEOSwift (0.5.1):
-    - GEOSwift/Core (= 0.5.1)
-  - GEOSwift/Core (0.5.1):
+  - GEOSwift (2.2.0):
     - geos (= 3.5.0)
-  - Mapbox-iOS-SDK (3.3.4)
+  - Mapbox-iOS-SDK (4.0.1)
 
 DEPENDENCIES:
   - GEOSwift
   - Mapbox-iOS-SDK
 
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - geos
+    - GEOSwift
+    - Mapbox-iOS-SDK
+
 SPEC CHECKSUMS:
   geos: e96c6ca3f3ce02d20feaa8d90d4af383e11e7198
-  GEOSwift: 7a3e070ee189ea27d3bcb6ba5244bf69d4f953aa
-  Mapbox-iOS-SDK: b22da0d9703fcfb0a8b592b6a7f6a21264fe44b0
+  GEOSwift: 8633f4f613d8c010eec90d26a6b7efd15bb98a51
+  Mapbox-iOS-SDK: 09b978be732d753e5c5e2911460fc0a018ce9be6
 
 PODFILE CHECKSUM: ab72b494530c13dc57e62fdeb5990f080ee54663
 
-COCOAPODS: 1.2.1
+COCOAPODS: 1.5.0


### PR DESCRIPTION
Inspired from https://github.com/GEOSwift/GEOSwift/blob/6006a7493dc040909903559d6b49cfe5d0070ecc/GEOSwift/MapKit.swift#L123

I don't know if I should commit the Podfile.