### PR TITLE
Added MultiPolygon support for mapboxShapes

### DIFF
--- a/GEOSwiftMapboxGL/MapboxGLAnnotations.swift
+++ b/GEOSwiftMapboxGL/MapboxGLAnnotations.swift
@@ -50,7 +50,13 @@ extension Geometry : GEOSwiftMapboxGL {
             
             let polygon = MGLPolygon(coordinates: &exteriorRingCoordinates, count: UInt(exteriorRingCoordinates.count) /*, interiorPolygons: interiorRings*/)
             return polygon
-            
+                                     
+        case is MultiPolygon<Polygon>:
+          let mglPolygons = (self as! MultiPolygon).geometries.map({ (polygon: Polygon) -> MGLPolygon in
+            return polygon.mapboxShape() as! MGLPolygon
+          })
+          return MGLMultiPolygon(polygons: mglPolygons) 
+                                     
         default:
             let geometryCollectionOverlay = MGLShapesCollection(geometryCollection: (self as! GeometryCollection))
             return geometryCollectionOverlay


### PR DESCRIPTION
There's a really easy way to support creating a `MGLMultiPolygon` from `MultiPolygons` for Mapbox. A `MGLMultiPolygon` can be created by passing an array of `MGLPolygon`s (`[MGLPolygon]`). This is possible because each element in the `geometries` collection of a `MultiPolygon` can be parsed into a `MGLPolygon`